### PR TITLE
Make screenshots retain aspect ratio

### DIFF
--- a/Trump True or False/Views/ContentView.swift
+++ b/Trump True or False/Views/ContentView.swift
@@ -16,7 +16,7 @@ struct ContentView: View {
     var body: some View {
         VStack(spacing: 20) {
             Text("Guess which tweets are real!").bold().font(.title).foregroundColor(.gray)
-            Image(gameController.tweets[count].imageName).resizable().frame(width: UIScreen.main.bounds.width - 10, height: 100).scaledToFit()
+            Image(gameController.tweets[count].imageName).resizable().scaledToFit().frame(minWidth: UIScreen.main.bounds.width - 10, maxWidth: UIScreen.main.bounds.width - 10).frame(height: 200)
             
             Text("Score: \(score)")
             


### PR DESCRIPTION
This commit makes it so that screenshots of tweets now retain their original aspect ratio instead of getting
stretched.